### PR TITLE
Year handling

### DIFF
--- a/types-date.lisp
+++ b/types-date.lisp
@@ -42,7 +42,7 @@
     (%parse-error "parse error."))
   (let ((d (parse-unsigned-integer string :start 6 :end 8))
         (m (parse-unsigned-integer string :start 4 :end 6))
-        (y (parse-unsigned-integer string :start 0 :end 4)))
+        (y (max (parse-unsigned-integer string :start 0 :end 4) 1900)))
     (encode-date d m y)))
 
 


### PR DESCRIPTION
Years preceding 1900 are legitimate values in iCalendar but don't map to encoded date/time in Common Lisp. Some MS products use year values less than 1900; these cause problems with cl-icalendar. This is a lazy way to handle them (they tend to be iCalendar components where the year actually isn't significant). It seems like the best alternative, one which correctly accomodates such values, would be to use an extended universal-time (e.g., negative values for pre-1900) or some other date-time package that handles pre-1900 years...
